### PR TITLE
fix: return 500 error when an uncaught error occurs in async handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ exports.register = function(server, options, next) {
       asyncHandler(request, reply).catch(function(error) {
         var {name, message, stack} = error;
         request.log(['error', 'uncaught'], {name, message, stack});
+        reply(error instanceof Error ? error : new Error(error));
       });
     };
   });

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,14 @@ exports.register = function(server, options, next) {
 
     return function(request, reply) {
       asyncHandler(request, reply).catch(function(error) {
-        var {name, message, stack} = error;
-        request.log(['error', 'uncaught'], {name, message, stack});
-        reply(error instanceof Error ? error : new Error(error));
+        if (error instanceof Error) {
+          var {name, message, stack} = error;
+          request.log(['error', 'uncaught'], {name, message, stack});
+        } else {
+          request.log(['error', 'uncaught'], {name: 'Error', message: error});
+          error = new Error(error);
+        }
+        reply(error);
       });
     };
   });


### PR DESCRIPTION
hi,
we've had problems with using this, because you forgot to `reply(...)` with the error so methods were left hanging and timing out ... this fixes that issue
