### PR TITLE
Context aware async handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,23 @@ server.route({
   },
 });
 ```
+
+### Passing handler context
+
+You can pass in the context and handler separately, best for when the handler is a class function.
+
+```javascript
+const someClass = new someClass()
+
+server.route({
+  method: 'GET',
+  path: '/',
+  handler: {
+    // The handler is now called with the someClass context
+    async: {
+      handler: someClass.handler,
+      context: someClass
+    },
+  },
+});
+```

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@ var assert = require('assert');
 
 exports.register = function(server, options, next) {
   server.handler('async', function(route, options) {
-    var asyncHandler = options;
+    var asyncHandler = options.handler || options;
     assert.equal('function', typeof asyncHandler, 'The async route handler must be a function');
 
     return function(request, reply) {
-      asyncHandler.call(this, request, reply).catch(function(error) {
+      var context = options.context || this;
+      asyncHandler.call(context, request, reply).catch(function(error) {
         if (error instanceof Error) {
           var {name, message, stack} = error;
           request.log(['error', 'uncaught'], {name, message, stack});


### PR DESCRIPTION
Add support for passing the context along with the handler
Backwards compatible.

Fixes #11 

Any alternative suggestions on solving this in a cleaner way are more than welcome.